### PR TITLE
Adjustments to output CSVs

### DIFF
--- a/output.py
+++ b/output.py
@@ -265,7 +265,9 @@ class MajorOutput:
 
                 prereq_ids: List[int] = []
                 coreq_ids: List[int] = []
-                if code in prereqs:
+                # Math 18 has no prereqs because it only requires pre-calc,
+                # which we assume the student has credit for
+                if code in prereqs and code != ("MATH", "18"):
                     for alternatives in prereqs[code]:
                         find_prereq(prereq_ids, coreq_ids, alternatives)
 

--- a/output.py
+++ b/output.py
@@ -21,7 +21,7 @@ from parse import (
     major_codes,
     prereqs,
 )
-from parse_course_name import parse_course_name
+from parse_course_name import clean_course_title, parse_course_name
 
 __all__ = ["MajorOutput"]
 
@@ -274,7 +274,7 @@ class MajorOutput:
                 subject, number = code
                 yield [
                     str(course_id),
-                    course_title.strip("*^ "),  # Asterisks seem to break the site
+                    clean_course_title(course_title),
                     subject,
                     number,
                     ";".join(map(str, prereq_ids)),

--- a/parse_course_name.py
+++ b/parse_course_name.py
@@ -11,7 +11,7 @@ Exports:
 import re
 from typing import Literal, Optional, Tuple
 
-__all__ = ["parse_course_name"]
+__all__ = ["parse_course_name", "clean_course_title"]
 
 
 def parse_course_name(
@@ -46,3 +46,19 @@ def parse_course_name(
             return None
         return subject, number, has_lab if has_lab == "L" or has_lab == "X" else None
     return None
+
+
+def clean_course_title(title: str) -> str:
+    """
+    Cleans up the course title by removing asterisks and (see note)s.
+    """
+    title = title.strip("^* ¹")
+    match = re.match(r"(GE|DEI) */ *(GE|AWP|DEI)", title)
+    if match:
+        return "DEI" if match.group(1) == "DEI" or match.group(2) == "DEI" else "GE"
+    title = re.sub(r" */ *(GE|AWP|DEI)$", "", title, flags=re.I)
+    title = re.sub(
+        r" *\(\*?(see note|DEI APPROVED|DEI)\*?\)$|^1 ", "", title, flags=re.I
+    )
+    title = re.sub(r" +", " ", title)
+    return title


### PR DESCRIPTION
Fixes #37: math 18 no longer has any prerequisites

Fixes #38: course names no longer say "(see note)" or "/AWP" ([see here for before/after](https://github.com/SheepTester-forks/ExploratoryCurricularAnalytics/blob/14858074aa2fc6a2ce83456bbe1c2740ee874c00/course_names2.txt))