### PR TITLE
Number duplicate courses, handle missing colleges

### DIFF
--- a/output.py
+++ b/output.py
@@ -9,6 +9,7 @@ Exports:
     variable.
 """
 
+import enum
 from typing import Dict, Generator, Iterable, List, NamedTuple, Optional
 from college_names import college_names
 
@@ -53,7 +54,11 @@ class InputCourse(NamedTuple):
         if units is None:
             units = self.course.units
         return ProcessedCourse(
-            course_title, code or ("", ""), units, self.major_course, self.term
+            clean_course_title(course_title),
+            code or ("", ""),
+            units,
+            self.major_course,
+            self.term,
         )
 
 
@@ -228,6 +233,15 @@ class MajorOutput:
                 course_ids[course.code] = current_id
                 current_id += 1
 
+        # Get duplicate course titles so can start with "GE 1" and so on
+        course_titles = [course.course_title for course in processed_courses]
+        duplicate_titles = {
+            title: 0
+            for i, title in enumerate(course_titles)
+            if title in course_titles[0:i]
+        }
+
+        # 4. Get prerequisites and output
         def find_prereq(
             prereq_ids: List[int],
             coreq_ids: List[int],
@@ -243,7 +257,6 @@ class MajorOutput:
                         )
                         return
 
-        # 4. Get prerequisites and output
         # In case there are duplicate courses, only let a course in course_ids
         # get used once
         claimed_ids = set(course_ids.keys())
@@ -271,10 +284,14 @@ class MajorOutput:
                     for alternatives in prereqs[code]:
                         find_prereq(prereq_ids, coreq_ids, alternatives)
 
+                if course_title in duplicate_titles:
+                    course_title = f"{course_title} {duplicate_titles[course_title]}"
+                    duplicate_titles[course_title] += 1
+
                 subject, number = code
                 yield [
                     str(course_id),
-                    clean_course_title(course_title),
+                    course_title,
                     subject,
                     number,
                     ";".join(map(str, prereq_ids)),

--- a/output.py
+++ b/output.py
@@ -9,7 +9,6 @@ Exports:
     variable.
 """
 
-import enum
 from typing import Dict, Generator, Iterable, List, NamedTuple, Optional
 from college_names import college_names
 
@@ -285,8 +284,8 @@ class MajorOutput:
                         find_prereq(prereq_ids, coreq_ids, alternatives)
 
                 if course_title in duplicate_titles:
-                    course_title = f"{course_title} {duplicate_titles[course_title]}"
                     duplicate_titles[course_title] += 1
+                    course_title = f"{course_title} {duplicate_titles[course_title]}"
 
                 subject, number = code
                 yield [
@@ -304,6 +303,8 @@ class MajorOutput:
                 ]
 
     def output(self, college: Optional[str] = None) -> str:
+        if college is not None and college not in self.plans.plans:
+            raise KeyError(f"No degree plan available for {college}.")
         cols = DEGREE_PLAN_COLS if college else CURRICULUM_COLS
         csv = ""
         for line in rows_to_csv(self.output_plan(college), cols):

--- a/parse.py
+++ b/parse.py
@@ -289,4 +289,4 @@ major_codes = major_rows_to_dict(
 if __name__ == "__main__":
     print(prereqs["CAT", "1"])
     print(major_plans["CS26"].curriculum())
-    print(major_codes["CS26"])
+    print(major_codes.keys())

--- a/parse.py
+++ b/parse.py
@@ -144,6 +144,10 @@ class Plan(NamedTuple):
     quarters: List[List[PlannedCourse]]
 
 
+# College codes from least to most weird colleges (see #14)
+least_weird_colleges = ["TH", "WA", "SN", "MU", "FI", "RE", "SI"]
+
+
 class MajorPlans(NamedTuple):
     """
     Represents a major's set of academic plans. Contains plans for each college.
@@ -156,7 +160,7 @@ class MajorPlans(NamedTuple):
     major_code: str
     plans: Dict[str, Plan]
 
-    def curriculum(self, college: str = "TH") -> List[PlannedCourse]:
+    def curriculum(self, college: Optional[str] = None) -> List[PlannedCourse]:
         """
         Returns a list of courses based on the specified college's degree plan
         with college-specific courses removed. Can be used to create a
@@ -169,10 +173,17 @@ class MajorPlans(NamedTuple):
         The `overlaps_ge` attribute for these courses should be ignored (because
         there is no college whose GEs the course overlaps with).
 
-        The default college is intentionally set to Marshall (Third College)
-        because it appears to be a generally good college to base curricula off
-        of (see #14).
+        If no college is specified, it will try Marshall (Third College) by
+        default because it appears to be a generally good college to base
+        curricula off of (see #14). If there is no Marshall plan, it will try a
+        different college.
         """
+        if college is None:
+            for college_code in least_weird_colleges:
+                if college_code in self.plans:
+                    college = college_code
+            if college is None:
+                raise KeyError("Major has no college plans.")
         return [
             course
             for quarter in self.plans[college].quarters
@@ -287,6 +298,4 @@ major_codes = major_rows_to_dict(
 )
 
 if __name__ == "__main__":
-    print(prereqs["CAT", "1"])
-    print(major_plans["CS26"].curriculum())
-    print(major_codes.keys())
+    print(major_plans.keys())

--- a/upload.py
+++ b/upload.py
@@ -268,6 +268,8 @@ def upload_major(
             f"[{major_code}] Curriculum URL: https://curricularanalytics.org/curriculums/{curriculum_id}"
         )
     for college_code, college_name in college_names.items():
+        if college_code not in output.plans.plans:
+            continue
         upload_degree_plan(
             curriculum_id,
             f"{major_code}/{college_name}",


### PR DESCRIPTION
Fixes #38/fixes #35 by adding numbers (starting at 1) for courses of the same title. For example, in the degree plans there are often multiple "GE" or "ELECTIVE" or "Alternative" (Seventh). In the uploaded versions, these are numbered, so the generated version numbers them as well.

Fixes #5, fixes #6 by just skipping over colleges (rather than crashing) that don't have an academic plan.